### PR TITLE
Correcting typo in item_grids.json that was preventing STT keys from …

### DIFF
--- a/layouts/item_grids.json
+++ b/layouts/item_grids.json
@@ -792,7 +792,7 @@
                   },
                   {
                     "type": "item",
-                    "item": "mm_stonetoweMM_SMALL_KEY_STr_small_keys",
+                    "item": "MM_SMALL_KEY_ST",
                     "margin": "1,2",
                     "width": 16,
                     "height": 16


### PR DESCRIPTION
…appearing in the tracker.