### PR TITLE
Fix "special", refactor caching, implement masks()

### DIFF
--- a/scripts/load_updaters.lua
+++ b/scripts/load_updaters.lua
@@ -1,21 +1,15 @@
 ScriptHost:LoadScript("scripts/update_maps.lua")
 
 function tracker_on_begin_loading_save_file()
-  if OOTMM_RESET_LOGIC then
-    OOTMM_RESET_LOGIC()
-  end
-
   PACK_READY = false
 end
 
 function tracker_on_finish_loading_save_file()
-  if OOTMM_RESET_LOGIC then
-    OOTMM_RESET_LOGIC()
-  end
+  OOTMM_RESET_LOGIC()
 end
 
 function tracker_on_accessibility_updating()
-  if OOTMM_RESET_LOGIC then
+  if PACK_READY then
     OOTMM_RESET_LOGIC()
   end
 end
@@ -23,7 +17,7 @@ end
 function tracker_on_accessibility_updated()
   if PACK_READY then
     clear_amount_cache()
-    
+
     if update_maps then
       update_maps()
     end
@@ -38,9 +32,9 @@ function tracker_on_accessibility_updated()
 end
 
 function tracker_on_pack_ready()
-  if OOTMM_RESET_LOGIC then
-    OOTMM_RESET_LOGIC()
-  end
+  OOTMM_RESET_LOGIC()
+  get_object("dummy").Active = not get_object("dummy").Active
+
 
   PACK_READY = true
 end

--- a/scripts/mm_logic.lua
+++ b/scripts/mm_logic.lua
@@ -87,9 +87,13 @@ function _mm_logic()
         ["STONE_SAPPHIRE"] = "SPIRITUAL_STONE:3", -- FIXME: has_spiritual_stones() macro will have to be adjusted on the fly.
     }
     if EMO then
-        function _has(item, min_count)
+        function _has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("EMO has:", item, min_count)
+            end
+
+            if use_prefix == nil then
+                use_prefix = true
             end
 
             if min_count and OOTMM_HAS_OVERRIDES[item .. ":" .. min_count] then
@@ -99,7 +103,7 @@ function _mm_logic()
             end
 
             local item_code = ""
-            if string.match(item, "^setting_") or string.match(item, "^TRICK_") or string.match(item, "^EVENT_") then
+            if not use_prefix or string.match(item, "^setting_") or string.match(item, "^TRICK_") or string.match(item, "^EVENT_") then
                 -- These are already prefixed as needed
                 item_code = item
             else
@@ -117,9 +121,13 @@ function _mm_logic()
             end
         end
     else
-        function _has(item, min_count)
+        function _has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("Debug has:", item, min_count)
+            end
+
+            if use_prefix == nil then
+                use_prefix = true
             end
 
             if min_count and OOTMM_HAS_OVERRIDES[item .. ":" .. min_count] then
@@ -140,21 +148,30 @@ function _mm_logic()
     end
 
     -- Tracker:ProviderCountForCode() calls are excruciatingly slow, this caches the results.
-    function has(item, count)
+    function has(item, count, use_prefix)
         if OOTMM_DEBUG then
             return _has(item, count)
         end
 
+        if use_prefix == nil then
+            use_prefix = true
+        end
+
+        local cache_key = tostring(use_prefix) .. ":" .. item
+        if count then
+            cache_key = cache_key .. ":" .. count
+        end
+
         if count == nil then
-            if OOTMM_RUNTIME_CACHE[item] == nil then
-                OOTMM_RUNTIME_CACHE[item] = _has(item, count)
+            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
+                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
             end
-            return OOTMM_RUNTIME_CACHE[item]
+            return OOTMM_RUNTIME_CACHE[cache_key]
         else
-            if OOTMM_RUNTIME_CACHE[item .. ":" .. count] == nil then
-                OOTMM_RUNTIME_CACHE[item .. ":" .. count] = _has(item, count)
+            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
+                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
             end
-            return OOTMM_RUNTIME_CACHE[item .. ":" .. count]
+            return OOTMM_RUNTIME_CACHE[cache_key]
         end
     end
 
@@ -307,7 +324,16 @@ function _mm_logic()
         return has("setting_" .. item_name)
     end
 
+    OOTMM_SPECIAL_ACCESS_CASES = {
+        ["BRIDGE"] = true,
+        ["MOON"] = true,
+    }
     function special(case)
+        if not OOTMM_SPECIAL_ACCESS_CASES[case] then
+            print("Unknown special name: " .. case)
+            return false
+        end
+
         local item_names = {
             "OOT_SPIRITUAL_STONE",
             "OOT_MEDALLION",
@@ -327,13 +353,12 @@ function _mm_logic()
 
         local sum = 0
         for _, item_name in pairs(item_names) do
-            local setting_name = string.lower("setting_" .. case .. "_" .. item_name)
+            local setting_name = "setting_" .. case .. "_" .. item_name
             if Tracker:ProviderCountForCode(setting_name) then
                 sum = sum + Tracker:ProviderCountForCode(item_name)
             end
         end
 
-        -- BRIDGE or MOON right now; + GANON_BK, LACS, MAJORA soon
         local needed = Tracker:ProviderCountForCode(case)
 
         return sum >= needed

--- a/scripts/mm_logic.lua
+++ b/scripts/mm_logic.lua
@@ -87,7 +87,7 @@ function _mm_logic()
         ["STONE_SAPPHIRE"] = "SPIRITUAL_STONE:3", -- FIXME: has_spiritual_stones() macro will have to be adjusted on the fly.
     }
     if EMO then
-        function _has(item, min_count, use_prefix)
+        function has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("EMO has:", item, min_count)
             end
@@ -112,7 +112,7 @@ function _mm_logic()
                 item_code = OOTMM_ITEM_PREFIX .. "_" .. item
             end
 
-            local count = Tracker:ProviderCountForCode(item_code)
+            local count = get_tracker_count(item_code)
 
             if not min_count then
                 return count > 0
@@ -121,7 +121,7 @@ function _mm_logic()
             end
         end
     else
-        function _has(item, min_count, use_prefix)
+        function has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("Debug has:", item, min_count)
             end
@@ -148,31 +148,18 @@ function _mm_logic()
     end
 
     -- Tracker:ProviderCountForCode() calls are excruciatingly slow, this caches the results.
-    function has(item, count, use_prefix)
+    function get_tracker_count(item_code)
         if OOTMM_DEBUG then
-            return _has(item, count)
+            return Tracker:ProviderCountForCode(item_code)
         end
 
-        if use_prefix == nil then
-            use_prefix = true
+        local cache_key = "RAW:" .. item_code
+
+        if OOTMM_RUNTIME_CACHE[cache_key] == nil then
+            OOTMM_RUNTIME_CACHE[cache_key] = Tracker:ProviderCountForCode(item_code)
         end
 
-        local cache_key = tostring(use_prefix) .. ":" .. item
-        if count then
-            cache_key = cache_key .. ":" .. count
-        end
-
-        if count == nil then
-            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
-                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
-            end
-            return OOTMM_RUNTIME_CACHE[cache_key]
-        else
-            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
-                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
-            end
-            return OOTMM_RUNTIME_CACHE[cache_key]
-        end
+        return OOTMM_RUNTIME_CACHE[cache_key]
     end
 
     child = true
@@ -354,14 +341,19 @@ function _mm_logic()
         local sum = 0
         for _, item_name in pairs(item_names) do
             local setting_name = "setting_" .. case .. "_" .. item_name
-            if Tracker:ProviderCountForCode(setting_name) then
-                sum = sum + Tracker:ProviderCountForCode(item_name)
+
+            if get_tracker_count(setting_name) then
+                sum = sum + get_tracker_count(item_name)
             end
         end
 
-        local needed = Tracker:ProviderCountForCode(case)
+        local needed = get_tracker_count(case)
 
         return sum >= needed
+    end
+
+    function masks(amount)
+        return get_tracker_count(OOTMM_ITEM_PREFIX .. "MASK") >= amount
     end
 
     function oot_time(x)

--- a/scripts/oot_logic.lua
+++ b/scripts/oot_logic.lua
@@ -87,9 +87,13 @@ function _oot_logic()
         ["STONE_SAPPHIRE"] = "SPIRITUAL_STONE:3", -- FIXME: has_spiritual_stones() macro will have to be adjusted on the fly.
     }
     if EMO then
-        function _has(item, min_count)
+        function _has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("EMO has:", item, min_count)
+            end
+
+            if use_prefix == nil then
+                use_prefix = true
             end
 
             if min_count and OOTMM_HAS_OVERRIDES[item .. ":" .. min_count] then
@@ -99,7 +103,7 @@ function _oot_logic()
             end
 
             local item_code = ""
-            if string.match(item, "^setting_") or string.match(item, "^TRICK_") or string.match(item, "^EVENT_") then
+            if not use_prefix or string.match(item, "^setting_") or string.match(item, "^TRICK_") or string.match(item, "^EVENT_") then
                 -- These are already prefixed as needed
                 item_code = item
             else
@@ -117,9 +121,13 @@ function _oot_logic()
             end
         end
     else
-        function _has(item, min_count)
+        function _has(item, min_count, use_prefix)
             if OOTMM_DEBUG then
                 print("Debug has:", item, min_count)
+            end
+
+            if use_prefix == nil then
+                use_prefix = true
             end
 
             if min_count and OOTMM_HAS_OVERRIDES[item .. ":" .. min_count] then
@@ -140,21 +148,30 @@ function _oot_logic()
     end
 
     -- Tracker:ProviderCountForCode() calls are excruciatingly slow, this caches the results.
-    function has(item, count)
+    function has(item, count, use_prefix)
         if OOTMM_DEBUG then
             return _has(item, count)
         end
 
+        if use_prefix == nil then
+            use_prefix = true
+        end
+
+        local cache_key = tostring(use_prefix) .. ":" .. item
+        if count then
+            cache_key = cache_key .. ":" .. count
+        end
+
         if count == nil then
-            if OOTMM_RUNTIME_CACHE[item] == nil then
-                OOTMM_RUNTIME_CACHE[item] = _has(item, count)
+            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
+                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
             end
-            return OOTMM_RUNTIME_CACHE[item]
+            return OOTMM_RUNTIME_CACHE[cache_key]
         else
-            if OOTMM_RUNTIME_CACHE[item .. ":" .. count] == nil then
-                OOTMM_RUNTIME_CACHE[item .. ":" .. count] = _has(item, count)
+            if OOTMM_RUNTIME_CACHE[cache_key] == nil then
+                OOTMM_RUNTIME_CACHE[cache_key] = _has(item, count, use_prefix)
             end
-            return OOTMM_RUNTIME_CACHE[item .. ":" .. count]
+            return OOTMM_RUNTIME_CACHE[cache_key]
         end
     end
 
@@ -307,7 +324,16 @@ function _oot_logic()
         return has("setting_" .. item_name)
     end
 
+    OOTMM_SPECIAL_ACCESS_CASES = {
+        ["BRIDGE"] = true,
+        ["MOON"] = true,
+    }
     function special(case)
+        if not OOTMM_SPECIAL_ACCESS_CASES[case] then
+            print("Unknown special name: " .. case)
+            return false
+        end
+
         local item_names = {
             "OOT_SPIRITUAL_STONE",
             "OOT_MEDALLION",
@@ -327,13 +353,12 @@ function _oot_logic()
 
         local sum = 0
         for _, item_name in pairs(item_names) do
-            local setting_name = string.lower("setting_" .. case .. "_" .. item_name)
+            local setting_name = "setting_" .. case .. "_" .. item_name
             if Tracker:ProviderCountForCode(setting_name) then
                 sum = sum + Tracker:ProviderCountForCode(item_name)
             end
         end
 
-        -- BRIDGE or MOON right now; + GANON_BK, LACS, MAJORA soon
         local needed = Tracker:ProviderCountForCode(case)
 
         return sum >= needed

--- a/scripts/staticfunctions.lua
+++ b/scripts/staticfunctions.lua
@@ -296,7 +296,7 @@ local function reset_logic(world)
         -- child + adult
         OOTMM[world].locations_normal = OOTMM[world].state.find_available_locations()
     end
-    OOTMM[world]["events_normal"] = OOTMM[world].state.get_reachable_events()
+    OOTMM[world].events_normal = OOTMM[world].state.get_reachable_events()
 
     OOTMM[world].state.set_trick_mode("all")
     if world == "mm" then
@@ -306,7 +306,7 @@ local function reset_logic(world)
         -- child + adult
         OOTMM[world].locations_glitched = OOTMM[world].state.find_available_locations()
     end
-    OOTMM[world]["events_glitched"] = OOTMM[world].state.get_reachable_events()
+    OOTMM[world].events_glitched = OOTMM[world].state.get_reachable_events()
 
     OOTMM_RESET_LOGIC_FLAG[world] = false
 end


### PR DESCRIPTION
special() now adheres to the little conventions we have - it now checks for "setting_BRIDGE_OOT_MASK", for example, where before it checked for lowercase everything.

Caching is now a lot simpler and caches less, but is only about 2% slower. This is fine and leads to more readable code. Additionally it can now be used for masks() lookups as well, which was problematic before.

masks() now checks for "{OOT,MM}_MASKS" amount.