### PR TITLE
Fix some rupees being counted twice

### DIFF
--- a/scripts/mm_logic.lua
+++ b/scripts/mm_logic.lua
@@ -855,6 +855,7 @@ function _mm_logic()
         ["Spirit Temple SR Sun 4"] = "RUPEE_SILVER_SPIRIT_SUN",
         ["Spirit Temple SR Sun 5"] = "RUPEE_SILVER_SPIRIT_SUN",
     }
+    local CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN = {}
     local function check_rule(node, earliest_time, used_events)
         -- Check the rule and return its result as well as all used events.
         OOTMM_RUNTIME_STATE["_check_rule_events_used"] = {}
@@ -919,7 +920,9 @@ function _mm_logic()
         end
 
         -- Handle special "custom event items"
-        if result and CUSTOM_EVENT_ITEMS_LOCATIONS[node.name] then
+        if result and CUSTOM_EVENT_ITEMS_LOCATIONS[node.name] and not CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN[node.name] then
+             -- Some checks are duplicated, but should not be counted twice for the same kind of collection. Remember which ones we've seen and counted before.
+            CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN[node.name] = true
             local item = CUSTOM_EVENT_ITEMS_LOCATIONS[node.name]
             local amount = OOTMM_RUNTIME_STATE["custom_event_items"][item] or 0
             amount = amount + 1

--- a/scripts/oot_logic.lua
+++ b/scripts/oot_logic.lua
@@ -855,6 +855,7 @@ function _oot_logic()
         ["Spirit Temple SR Sun 4"] = "RUPEE_SILVER_SPIRIT_SUN",
         ["Spirit Temple SR Sun 5"] = "RUPEE_SILVER_SPIRIT_SUN",
     }
+    local CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN = {}
     local function check_rule(node, earliest_time, used_events)
         -- Check the rule and return its result as well as all used events.
         OOTMM_RUNTIME_STATE["_check_rule_events_used"] = {}
@@ -919,7 +920,9 @@ function _oot_logic()
         end
 
         -- Handle special "custom event items"
-        if result and CUSTOM_EVENT_ITEMS_LOCATIONS[node.name] then
+        if result and CUSTOM_EVENT_ITEMS_LOCATIONS[node.name] and not CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN[node.name] then
+             -- Some checks are duplicated, but should not be counted twice for the same kind of collection. Remember which ones we've seen and counted before.
+            CUSTOM_EVENT_ITEMS_LOCATIONS_SEEN[node.name] = true
             local item = CUSTOM_EVENT_ITEMS_LOCATIONS[node.name]
             local amount = OOTMM_RUNTIME_STATE["custom_event_items"][item] or 0
             amount = amount + 1


### PR DESCRIPTION
The fact that some checks are in the logic more than once was news to me. Still not sure whether the randomizer actually properly handles this instead of silently dropping some items on a check twice, but we now handle the base case in the map tracker in order to show the right checks being available.